### PR TITLE
Renamed beforeDestroy to beforeUnmount

### DIFF
--- a/src/components/VgtTableHeader.vue
+++ b/src/components/VgtTableHeader.vue
@@ -274,7 +274,7 @@ export default {
       }
     });
   },
-  beforeDestroy() {
+  beforeUnmount() {
     if (this.ro) {
       this.ro.disconnect();
     }


### PR DESCRIPTION
This hook was renamed in Vue 3
https://v3-migration.vuejs.org/breaking-changes/#other-minor-changes