### PR TITLE
Compat warnings fix

### DIFF
--- a/src/components/VgtTableHeader.vue
+++ b/src/components/VgtTableHeader.vue
@@ -119,6 +119,7 @@ export default {
         this.setColumnStyles();
       },
       immediate: true,
+      deep: true
     },
     tableRef: {
       handler() {

--- a/src/components/VgtTableHeader.vue
+++ b/src/components/VgtTableHeader.vue
@@ -274,7 +274,7 @@ export default {
       }
     });
   },
-  beforeDestroy() {
+  beforeUnmount() {
     if (this.ro) {
       this.ro.disconnect();
     }

--- a/src/components/pagination/VgtPagination.vue
+++ b/src/components/pagination/VgtPagination.vue
@@ -102,8 +102,11 @@ export default {
       immediate: true,
     },
 
-    customRowsPerPageDropdown() {
-      this.handlePerPage();
+    customRowsPerPageDropdown: {
+      handler() {
+        this.handlePerPage();
+      },
+      deep: true,
     },
 
     total: {


### PR DESCRIPTION
This patch fixes every vue/compat warning except one – produced by `selectedRows` watch method; because `selectedRows` is a computed property that creates new array each time, setting watch option to `deep: true` might be unnecessary.