### PR TITLE
Update VgtGlobalSearch.vue

### DIFF
--- a/src/components/VgtGlobalSearch.vue
+++ b/src/components/VgtGlobalSearch.vue
@@ -32,7 +32,7 @@ export default {
   props: [
     'value',
     'searchEnabled',
-    'globalSearchPlaceholder',
+    'global-search-placeholder',
   ],
   emits: [
     'input',


### PR DESCRIPTION
When using ViteJS to build for prod, we are getting an error. It works fine with npm run dev.

"Uncaught (in promise) DOMException: Failed to execute 'setAttribute' on 'Element': '{}-search-placeholder' is not a valid attribute name". 

I modified the file to use kebab-case in quotes in the prop and that seemed to have gotten rid of the error and the page now loads.

Not sure why the camel case didn't work. 