### PR TITLE
Grouped Header Row Checkbox issue

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1121,7 +1121,7 @@ export default {
 
 		toggleSelectGroup(event, headerRow) {
 			headerRow.children.forEach((row) => {
-				row["vgtSelected"] = event;
+				row["vgtSelected"] = event.checked;
 			});
 		},
 


### PR DESCRIPTION
If checkbox of grouped header row is unchecked, all children are unselected too.