### PR TITLE
fix(Table): Updated key reference to row-click listener

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1004,7 +1004,7 @@ export default {
 		},
 
 		hasRowClickListener() {
-			return this.$attrs && this.$attrs["row-click"];
+			return this.$attrs && this.$attrs['onRowClick'];
 		},
 	},
 


### PR DESCRIPTION
Listeners are now prefixed with `on` and are camel case... `row-click` is now `onRowClick`.
Before this fix, the `.clickable` class was not being applied to rows.