### PR TITLE
Updated group-options object syntax 

### DIFF
--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -166,7 +166,7 @@ The expanded and collapsed state will then be maintained.
   :rows="rows"
   :group-options="{
     enabled: true,
-    rowKey="id"
+    rowKey:"id",
     collapsable: true // or column index
   }"
 >


### PR DESCRIPTION
the documentation was incorrect. this fixes the syntax